### PR TITLE
appinfo.json: Add requiredPermissions for LuneOS

### DIFF
--- a/enyo-app/appinfo.json
+++ b/enyo-app/appinfo.json
@@ -7,5 +7,6 @@
 	"title": "Check Mate HD",
 	"splashicon": "icon-splash.png",
 	"icon": "icon.png",
-	"uiRevision": 2
+	"uiRevision": 2,
+	"requiredPermissions": ["application.launcher", "location-service.operation", "luna-sysmgr.operation", "networkconnection.query", "preferences.system"]
 }


### PR DESCRIPTION
LuneOS uses LS2 service bus with Enhanced ACG which requires app to specify their required permissions.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>